### PR TITLE
refactor: simulator

### DIFF
--- a/src/actors/client.zig
+++ b/src/actors/client.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+
 const Network = @import("../network.zig").Network;
 const PRNG = @import("../prng.zig").PRNG;
 const Simulator = @import("../simulator.zig").Simulator; // Forward declare

--- a/src/actors/mod.zig
+++ b/src/actors/mod.zig
@@ -1,2 +1,0 @@
-pub const ClientActor = @import("client.zig").ClientActor;
-pub const ReplicaActor = @import("replica.zig").ReplicaActor;

--- a/src/actors/replica.zig
+++ b/src/actors/replica.zig
@@ -1,5 +1,5 @@
-// src/actors/replica.zig
 const std = @import("std");
+
 const Network = @import("../network.zig").Network;
 const Simulator = @import("../simulator.zig").Simulator;
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -33,7 +33,7 @@ pub const SimulationConfig = struct {
         try writer.print("\tmax_ticks: {},\n", .{self.max_ticks});
         try writer.print("\tnum_replicas: {},\n", .{self.num_replicas});
         try writer.print("\tnum_clients: {},\n", .{self.num_clients});
-        try writer.print("\treplica_pause_probability: {},\n", .{self.replica_pause_probability});
+        try writer.print("\treplica_pause_probability: {d},\n", .{self.replica_pause_probability});
         try writer.writeAll("}\n");
     }
 };

--- a/src/config.zig
+++ b/src/config.zig
@@ -18,6 +18,24 @@ pub const SimulationConfig = struct {
     // TODO: Add network partition config
     // TODO: Add DB-specific options (union based on target DB)
     // TODO: Add workload configuration
+
+    pub fn format(
+        self: @This(),
+        comptime fmt: []const u8,
+        options: std.fmt.FormatOptions,
+        writer: anytype,
+    ) !void {
+        _ = fmt;
+        _ = options;
+
+        try writer.writeAll("Config{\n");
+        try writer.print("\tseed: {},\n", .{self.seed});
+        try writer.print("\tmax_ticks: {},\n", .{self.max_ticks});
+        try writer.print("\tnum_replicas: {},\n", .{self.num_replicas});
+        try writer.print("\tnum_clients: {},\n", .{self.num_clients});
+        try writer.print("\treplica_pause_probability: {},\n", .{self.replica_pause_probability});
+        try writer.writeAll("}\n");
+    }
 };
 
 // Potential future function for loading from file

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
+
 const clap = @import("clap");
+
 const config = @import("config.zig");
 const Simulator = @import("simulator.zig").Simulator;
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -33,7 +33,7 @@ pub fn main() !void {
     // --- Build Configuration ---
     // Use 'orelse' with defaults from config.zig
     const seed: u64 = res.args.seed orelse std.crypto.random.int(u64);
-    const simulatorConfig = config.SimulationConfig{
+    const simulation_config = config.SimulationConfig{
         .seed = seed,
         .max_ticks = res.args.ticks orelse config.default_max_ticks,
         .num_replicas = res.args.replicas orelse config.default_num_replicas,
@@ -41,10 +41,10 @@ pub fn main() !void {
         .replica_pause_probability = res.args.pause_prob orelse config.default_replica_pause_probability,
     };
 
-    std.log.info("Initializing simulation with config: {any}", .{config});
+    std.log.info("Initializing simulation with config: {any}", .{simulation_config});
 
     // --- Initialize and Run Simulator ---
-    var sim = try Simulator.init(allocator, simulatorConfig);
+    var sim = try Simulator.init(allocator, simulation_config);
     defer sim.deinit(); // Ensure cleanup
 
     try sim.run(); // Execute the main simulation loop

--- a/src/network.zig
+++ b/src/network.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+
 const Scheduler = @import("scheduler.zig").Scheduler;
 const PRNG = @import("prng.zig").PRNG;
 

--- a/src/scheduler.zig
+++ b/src/scheduler.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+
 const Simulator = @import("simulator.zig").Simulator;
 
 pub const Scheduler = struct {


### PR DESCRIPTION
This PR refactors some of the simulator components to be easier to understand, directly imports the actors instead of re-exporting to `mod.zig`.

Also renames `config_mod` to `config` and `config` to `simulation_config`