### PR TITLE
feat: implement event runner as for loop to max ticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The architecture of FRoST is roughly defined by the diagram below:
 - [x] Scratch standalone simulator based on TigerBeetle
       VOPR, PoC implementation
 - [x] Implement Replica Resume after Pause during tick
-- [ ] (IN PROGRESS: JOHN) Explore refactoring tick using for-loop vs while loop
+- [x] Explore refactoring tick using for-loop vs while loop
 - [ ] (IN PROGRESS: SHAOHONG) Evaluate FoundationDB simulator standalone:
       https://github.com/apple/foundationdb/tree/main/tests/TestRunner
       Evaluate rocksdb backend performance on dst.

--- a/src/actors/client.zig
+++ b/src/actors/client.zig
@@ -46,7 +46,7 @@ pub const ClientActor = struct {
             std.log.debug("Client {} performing action targeting replica {} @ tick {} (placeholder)", .{ self.id, target_replica_id, current_tick });
             // Example: Send a dummy message to a replica
             // Actor IDs need careful management. Assume replica IDs are 0..N-1
-            try self.network.sendMessage(self.id, target_replica_id, .{ .op = "dummy" });
+            try self.network.sendMessage(self.id, target_replica_id, .{ .op = "dummy" }, current_tick);
         }
     }
 };

--- a/src/network.zig
+++ b/src/network.zig
@@ -24,10 +24,10 @@ pub const Network = struct {
         _ = self;
     }
 
-    pub fn sendMessage(self: *Network, from_actor: u32, to_actor: u32, payload: anytype) !void {
+    pub fn sendMessage(self: *Network, from_actor: u32, to_actor: u32, payload: anytype, current_tick: u32) !void {
         // TODO: Use PRNG and config to determine latency
         const latency: u32 = 1 + self.prng.random().uintLessThan(u32, 10); // Example
-        const delivery_tick = self.scheduler.current_tick + latency; // Use scheduler's time
+        const delivery_tick = current_tick + latency; // Use scheduler's time
 
         // TODO: Use PRNG and config to check for drops/partitions
 
@@ -35,7 +35,7 @@ pub const Network = struct {
         const deliver_event = .{ .to = to_actor, .payload = payload }; // Placeholder
         try self.scheduler.scheduleEvent(delivery_tick, deliver_event);
 
-        std.log.debug("Network sending message from {} to {} @ tick {} (delivers @ {})", .{ from_actor, to_actor, self.scheduler.current_tick, delivery_tick });
+        std.log.debug("Network sending message from {} to {} @ tick {} (delivers @ {})", .{ from_actor, to_actor, current_tick, delivery_tick });
         // TODO: Figure out what to do with payload
         // _ = payload; // Silence unused warning
     }

--- a/src/scheduler.zig
+++ b/src/scheduler.zig
@@ -6,7 +6,6 @@ pub const Scheduler = struct {
     // TODO: Implement event queue (priority queue based on virtual time)
     // TODO: Manage runnable actors
     allocator: std.mem.Allocator,
-    current_tick: u32 = 0, // Scheduler needs to know the time for scheduling
 
     pub fn init(allocator: std.mem.Allocator) Scheduler {
         return Scheduler{ .allocator = allocator };
@@ -28,19 +27,17 @@ pub const Scheduler = struct {
 
     // Changed sim parameter type to avoid circular dependency issues initially.
     // Pass only needed parts or use interfaces later.
-    pub fn runTick(self: *Scheduler, sim_prng: *std.Random.DefaultPrng) !void {
+    pub fn runTick(self: *Scheduler, sim_prng: *std.Random.DefaultPrng, current_tick: u32) !void {
+        _ = self;
+        _ = sim_prng; // silence unused
+
         // TODO: Process events scheduled for self.current_tick
         // TODO: Decide which actors run this tick (using sim_prng for determinism)
         // TODO: Return list of actors to run, or directly call their 'step' methods?
         // TODO: Potentially trigger faults via sim.injectFaults() (maybe move fault injection call?)
 
-        if (self.current_tick % 100_000 == 0) { // Log progress occasionally
-            std.log.debug("Scheduler running tick {}", .{self.current_tick});
+        if (current_tick % 100_000 == 0) { // Log progress occasionally
+            std.log.debug("Scheduler running tick {}", .{current_tick});
         }
-        _ = sim_prng; // silence unused
-    }
-
-    pub fn advanceTick(self: *Scheduler) void {
-        self.current_tick += 1;
     }
 };


### PR DESCRIPTION
This PR makes `simulator.zig` the single source of truth for ticks, and also allows us to remove `advanceTick()` as a function in the scheduler.

The outcome of this change to a `for` loop does not have any performance regression compared to the old way of using a `while` loop as evaluated using `hyperfine`

```bash
$ hyperfine --warmup 3 "./while/bin/frost -s 0" "./for/bin/frost -s 0"
Benchmark 1: ./while/bin/frost -s 0
  Time (mean ± σ):      1.160 s ±  0.008 s    [User: 0.947 s, System: 0.205 s]
  Range (min … max):    1.151 s …  1.176 s    10 runs
 
Benchmark 2: ./for/bin/frost -s 0
  Time (mean ± σ):      1.155 s ±  0.016 s    [User: 0.940 s, System: 0.204 s]
  Range (min … max):    1.136 s …  1.179 s    10 runs
 
Summary
  ./for/bin/frost -s 0 ran
    1.00 ± 0.02 times faster than ./while/bin/frost -s 0
```